### PR TITLE
Include :aot [..] in project.clj 

### DIFF
--- a/flink-clojure/README.md
+++ b/flink-clojure/README.md
@@ -2,8 +2,7 @@ Small WordCount example on how to write a Flink program in Clojure.
 
 Steps to run this code with `lein`:
 
-1. run `lein compile org.apache.flink.clojure.WordCount`
-2. execute with `lein run`
+1. execute `lein run`
 
 Steps to run this code with `bin/flink`:
 

--- a/flink-clojure/project.clj
+++ b/flink-clojure/project.clj
@@ -3,10 +3,11 @@
   :url "https://github.com/mjsax/flink-external/tree/master/flink-clojure"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.apache.flink/flink-clients "0.10.2"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.apache.flink/flink-clients_2.11 "1.0.3"]]
   :source-paths ["src/main/clojure"]
   :java-source-paths ["src/main/java"]
   :test-paths ["src/test/clojure"]
   :resource-paths ["src/main/resource"]
+  :aot  [org.apache.flink.clojure.WordCount]
   :main org.apache.flink.clojure.WordCount)


### PR DESCRIPTION
I had problems running the example, since I forgot to run "lein compile .." first.

While researching this problem, I found that if we include ":aot [..]" in project.clj, the compilation will be done automatically and all we have to do is execute "lein run".

I have also updated to dependencies to clojure 1.8.0 and flink 1.0.3.

best regards,
    
     Fredrik