### PR TITLE
Properly attribute Apache trademarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-Some examples on how to use [Apache Flink](https://flink.apache.org).
+# Apache Flink™ Examples
+
+Some examples on how to use [Apache Flink™](https://flink.apache.org).
+
+
+## Disclaimer
+Apache®, Apache Flink™, Flink™, and the Apache feather logo are trademarks of [The Apache Software Foundation](http://apache.org).


### PR DESCRIPTION
I'm currently checking all repos linked from the flink website for proper trademark attribution, and I found  this repository which needed the proposed changes.